### PR TITLE
Handle httplib bad status line error

### DIFF
--- a/patchman/repos/utils.py
+++ b/patchman/repos/utils.py
@@ -173,7 +173,7 @@ def get_url(url):
             return -1
     except httplib.BadStatusLine, e:
         error_message.send(sender=None,
-            text='Http bad status line: %s - %e\n' % (url, e.line))
+            text='Http bad status line: %s - %s\n' % (url, e.line))
         return -1
 
 


### PR DESCRIPTION
When running `python /srv/django/patchman/sbin/patchman-cli -u -d -U -c -r -p -n`
we've been getting this exception thrown from a bad repo:

```
Traceback (most recent call last):
  File "/srv/django/patchman/sbin/patchman-cli", line 306, in <module>
    update_repos(args.repo)
  File "/srv/django/patchman/sbin/patchman-cli", line 80, in update_repos
    repo.update(force)
  File
"/usr/local/lib/python2.6/dist-packages/patchman/repos/models.py", line
68, in update
    update_rpm_repo(self)
  File "/usr/local/lib/python2.6/dist-packages/patchman/repos/utils.py",
line 391, in update_rpm_repo
    mirrorlists_check(repo)
  File "/usr/local/lib/python2.6/dist-packages/patchman/repos/utils.py",
line 225, in mirrorlists_check
    mirror_urls = mirrorlist_check(mirror.url)
  File "/usr/local/lib/python2.6/dist-packages/patchman/repos/utils.py",
line 209, in mirrorlist_check
    res = get_url(mirror_url)
  File "/usr/local/lib/python2.6/dist-packages/patchman/repos/utils.py",
line 156, in get_url
    res = urlopen(req)
  File "/usr/lib/python2.6/urllib2.py", line 126, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib/python2.6/urllib2.py", line 391, in open
    response = self._open(req, data)
  File "/usr/lib/python2.6/urllib2.py", line 409, in _open
    '_open', req)
  File "/usr/lib/python2.6/urllib2.py", line 369, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.6/urllib2.py", line 1170, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib/python2.6/urllib2.py", line 1143, in do_open
    r = h.getresponse()
  File "/usr/lib/python2.6/httplib.py", line 990, in getresponse
    response.begin()
  File "/usr/lib/python2.6/httplib.py", line 391, in begin
    version, status, reason = self._read_status()
  File "/usr/lib/python2.6/httplib.py", line 379, in _read_status
    raise BadStatusLine(line)
httplib.BadStatusLine: HTTP/1.0   0 Init
```

I think patchman should handle this error and keep going, rather than crash
 and leave reports unprocessed.

Perhaps give this a few more days of testing at this site (and test somewhere else?) before
merging.

Regards.
