### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/hooks/yum/patchman.py
+++ b/hooks/yum/patchman.py
@@ -10,5 +10,5 @@ def posttrans_hook(conduit):
     conduit.info(2, 'patchman: sending data')
     servicecmd = conduit.confString('main', 'servicecmd', '/usr/sbin/patchman-client')
     args = '-n'
-    command = '%s %s> /dev/null' % (servicecmd, args)
+    command = '{0!s} {1!s}> /dev/null'.format(servicecmd, args)
     os.system(command)

--- a/patchman/hosts/models.py
+++ b/patchman/hosts/models.py
@@ -59,21 +59,21 @@ class Host(models.Model):
         """ Show info about this host
         """
         text = []
-        text.append('%s:\n' % self)
-        text.append('IP address   : %s\n' % self.ipaddress)
-        text.append('Reverse DNS  : %s\n' % self.reversedns)
-        text.append('Domain       : %s\n' % self.domain)
-        text.append('OS           : %s\n' % self.os)
-        text.append('Kernel       : %s\n' % self.kernel)
-        text.append('Architecture : %s\n' % self.arch)
-        text.append('Last report  : %s\n' % self.lastreport)
-        text.append('Packages     : %s\n' % self.get_num_packages())
-        text.append('Repos        : %s\n' % self.get_num_repos())
-        text.append('Updates      : %s\n' % self.get_num_updates())
-        text.append('Tags         : %s\n' % self.tags)
-        text.append('Needs reboot : %s\n' % self.reboot_required)
-        text.append('Updated at   : %s\n' % self.updated_at)
-        text.append('Host repos   : %s\n' % self.host_repos_only)
+        text.append('{0!s}:\n'.format(self))
+        text.append('IP address   : {0!s}\n'.format(self.ipaddress))
+        text.append('Reverse DNS  : {0!s}\n'.format(self.reversedns))
+        text.append('Domain       : {0!s}\n'.format(self.domain))
+        text.append('OS           : {0!s}\n'.format(self.os))
+        text.append('Kernel       : {0!s}\n'.format(self.kernel))
+        text.append('Architecture : {0!s}\n'.format(self.arch))
+        text.append('Last report  : {0!s}\n'.format(self.lastreport))
+        text.append('Packages     : {0!s}\n'.format(self.get_num_packages()))
+        text.append('Repos        : {0!s}\n'.format(self.get_num_repos()))
+        text.append('Updates      : {0!s}\n'.format(self.get_num_updates()))
+        text.append('Tags         : {0!s}\n'.format(self.tags))
+        text.append('Needs reboot : {0!s}\n'.format(self.reboot_required))
+        text.append('Updated at   : {0!s}\n'.format(self.updated_at))
+        text.append('Host repos   : {0!s}\n'.format(self.host_repos_only))
         text.append('\n')
 
         for line in text:
@@ -105,8 +105,7 @@ class Host(models.Model):
                 info_message.send(sender=None, text='Reverse DNS matches\n')
             else:
                 info_message.send(sender=None,
-                                  text='Reverse DNS mismatch found: %s != %s\n'
-                                  % (self.hostname, self.reversedns))
+                                  text='Reverse DNS mismatch found: {0!s} != {1!s}\n'.format(self.hostname, self.reversedns))
         else:
             info_message.send(sender=None,
                               text='Reverse DNS check disabled\n')
@@ -159,7 +158,7 @@ class Host(models.Model):
         try:
             with transaction.atomic():
                 self.updates.add(update)
-            info_message.send(sender=None, text="%s\n" % update)
+            info_message.send(sender=None, text="{0!s}\n".format(update))
             return update.id
         except IntegrityError as e:
             print e
@@ -331,4 +330,4 @@ class HostRepo(models.Model):
         unique_together = ('host', 'repo')
 
     def __unicode__(self):
-        return '%s-%s' % (self.host, self.repo)
+        return '{0!s}-{1!s}'.format(self.host, self.repo)

--- a/patchman/hosts/south_migrations/0004_auto__add_unique_hostrepo_repo_host.py
+++ b/patchman/hosts/south_migrations/0004_auto__add_unique_hostrepo_repo_host.py
@@ -15,7 +15,7 @@ class Migration(SchemaMigration):
             # Remove existing duplicates
             hostrepos = []
             for hostrepo in orm.HostRepo.objects.all():
-                hr_string = '%s-%s' % (hostrepo.host.id, hostrepo.repo.id)
+                hr_string = '{0!s}-{1!s}'.format(hostrepo.host.id, hostrepo.repo.id)
                 if hr_string in hostrepos:
                     hostrepo.delete()
                 else:

--- a/patchman/hosts/utils.py
+++ b/patchman/hosts/utils.py
@@ -54,7 +54,7 @@ def remove_reports(host, timestamp):
     del_reports = Report.objects.filter(host=host).exclude(id__in=report_ids)
 
     rlen = del_reports.count()
-    ptext = 'Cleaning %s old reports' % rlen
+    ptext = 'Cleaning {0!s} old reports'.format(rlen)
     progress_info_s.send(sender=None, ptext=ptext, plen=rlen)
     for i, report in enumerate(del_reports):
         report.delete()

--- a/patchman/hosts/views.py
+++ b/patchman/hosts/views.py
@@ -139,7 +139,7 @@ def host_edit(request, hostname):
         if edit_form.is_valid():
             host = edit_form.save()
             host.save()
-            messages.info(request, 'Saved changes to Host %s' % host)
+            messages.info(request, 'Saved changes to Host {0!s}'.format(host))
             return HttpResponseRedirect(host.get_absolute_url())
         else:
             host = get_object_or_404(Host, hostname=hostname)
@@ -161,7 +161,7 @@ def host_delete(request, hostname):
     if request.method == 'POST':
         if 'delete' in request.REQUEST:
             host.delete()
-            messages.info(request, 'Host %s has been deleted' % hostname)
+            messages.info(request, 'Host {0!s} has been deleted'.format(hostname))
             return HttpResponseRedirect(reverse('host_list'))
         elif 'cancel' in request.REQUEST:
             return HttpResponseRedirect(reverse('host_detail',

--- a/patchman/operatingsystems/views.py
+++ b/patchman/operatingsystems/views.py
@@ -103,12 +103,12 @@ def os_delete(request, os_id):
         if 'delete' in request.REQUEST:
             if os:
                 os.delete()
-                messages.info(request, 'OS %s has been deleted' % os)
+                messages.info(request, 'OS {0!s} has been deleted'.format(os))
                 return HttpResponseRedirect(reverse('os_list'))
             if oses:
                 for os in oses:
                     os.delete()
-                text = '%s OS\'s have been deleted' % len(oses)
+                text = '{0!s} OS\'s have been deleted'.format(len(oses))
                 messages.info(request, text)
                 return HttpResponseRedirect(reverse('os_list'))
         elif 'cancel' in request.REQUEST:
@@ -181,7 +181,7 @@ def osgroup_delete(request, osgroup_id):
     if request.method == 'POST':
         if 'delete' in request.REQUEST:
             osgroup.delete()
-            messages.info(request, 'OS Group %s has been deleted' % osgroup)
+            messages.info(request, 'OS Group {0!s} has been deleted'.format(osgroup))
             return HttpResponseRedirect(reverse('os_list'))
         elif 'cancel' in request.REQUEST:
             oid = osgroup_id

--- a/patchman/packages/models.py
+++ b/patchman/packages/models.py
@@ -72,14 +72,14 @@ class Package(models.Model):
 
     def __unicode__(self):
         if self.epoch:
-            epo = '%s:' % self.epoch
+            epo = '{0!s}:'.format(self.epoch)
         else:
             epo = ''
         if self.release:
-            rel = '-%s' % self.release
+            rel = '-{0!s}'.format(self.release)
         else:
             rel = ''
-        return '%s-%s%s%s-%s' % (self.name, epo, self.version, rel, self.arch)
+        return '{0!s}-{1!s}{2!s}{3!s}-{4!s}'.format(self.name, epo, self.version, rel, self.arch)
 
     def get_absolute_url(self):
         return self.name.get_absolute_url()
@@ -151,14 +151,14 @@ class PackageString(models.Model):
 
     def __unicode__(self):
         if self.epoch:
-            epo = '%s:' % self.epoch
+            epo = '{0!s}:'.format(self.epoch)
         else:
             epo = ''
         if self.release:
-            rel = '-%s' % self.release
+            rel = '-{0!s}'.format(self.release)
         else:
             rel = ''
-        return '%s-%s%s%s-%s' % (self.name, epo, self.version, rel, self.arch)
+        return '{0!s}-{1!s}{2!s}{3!s}-{4!s}'.format(self.name, epo, self.version, rel, self.arch)
 
     def __key(self):
         return (self.name, self.epoch, self.version, self.release, self.arch,
@@ -190,5 +190,5 @@ class PackageUpdate(models.Model):
             update_type = 'Security'
         else:
             update_type = 'Bugfix'
-        return '%s -> %s (%s)' % (self.oldpackage, self.newpackage,
+        return '{0!s} -> {1!s} ({2!s})'.format(self.oldpackage, self.newpackage,
                                   update_type)

--- a/patchman/packages/utils.py
+++ b/patchman/packages/utils.py
@@ -49,12 +49,12 @@ def find_version(s, epoch, release):
     """ Given a package version string, return the version """
 
     try:
-        es = '%s:' % epoch
+        es = '{0!s}:'.format(epoch)
         e = s.index(es) + len(epoch) + 1
     except ValueError:
         e = 0
     try:
-        rs = '-%s' % release
+        rs = '-{0!s}'.format(release)
         r = s.index(rs)
     except ValueError:
         r = len(s)

--- a/patchman/reports/models.py
+++ b/patchman/reports/models.py
@@ -49,7 +49,7 @@ class Report(models.Model):
         ordering = ('-created',)
 
     def __unicode__(self):
-        return '%s %s' % (self.host, self.created)
+        return '{0!s} {1!s}'.format(self.host, self.created)
 
     @models.permalink
     def get_absolute_url(self):
@@ -134,7 +134,7 @@ class Report(models.Model):
             host.check_rdns()
 
             if verbose:
-                print 'Processing report %s - %s' % (self.id, self.host)
+                print 'Processing report {0!s} - {1!s}'.format(self.id, self.host)
 
             from patchman.reports.utils import process_packages, \
                 process_repos, process_updates
@@ -151,14 +151,12 @@ class Report(models.Model):
 
             if find_updates:
                 if verbose:
-                    print 'Finding updates for report %s - %s' % \
-                        (self.id, self.host)
+                    print 'Finding updates for report {0!s} - {1!s}'.format(self.id, self.host)
                 host.find_updates()
         else:
             if self.processed:
-                text = 'Report %s has already been processed\n' % (self.id)
+                text = 'Report {0!s} has already been processed\n'.format((self.id))
                 info_message.send(sender=None, text=text)
             else:
-                text = 'Error: OS, kernel or arch not sent with report %s\n' \
-                    % (self.id)
+                text = 'Error: OS, kernel or arch not sent with report {0!s}\n'.format((self.id))
                 error_message.send(sender=None, text=text)

--- a/patchman/reports/utils.py
+++ b/patchman/reports/utils.py
@@ -37,7 +37,7 @@ def process_repos(report, host):
 
         repos = parse_repos(report.repos)
         progress_info_s.send(sender=None,
-                             ptext='%s repos' % host.__unicode__()[0:25],
+                             ptext='{0!s} repos'.format(host.__unicode__()[0:25]),
                              plen=len(repos))
         for i, repo_str in enumerate(repos):
             repo, priority = process_repo(repo_str, report.arch)
@@ -73,7 +73,7 @@ def process_packages(report, host):
 
         packages = parse_packages(report.packages)
         progress_info_s.send(sender=None,
-                             ptext='%s packages' % host.__unicode__()[0:25],
+                             ptext='{0!s} packages'.format(host.__unicode__()[0:25]),
                              plen=len(packages))
         for i, pkg_str in enumerate(packages):
             package = process_package(pkg_str, report.protocol)
@@ -87,7 +87,7 @@ def process_packages(report, host):
                 except DatabaseError as e:
                     print e
             else:
-                print 'No package returned for %s' % pkg_str
+                print 'No package returned for {0!s}'.format(pkg_str)
             progress_update_s.send(sender=None, index=i + 1)
 
         removals = old_packages.exclude(pk__in=package_ids)
@@ -117,7 +117,7 @@ def add_updates(updates, host, security):
         extra = 'bug'
 
     if ulen > 0:
-        ptext = '%s %s updates' % (host.__unicode__()[0:25], extra)
+        ptext = '{0!s} {1!s} updates'.format(host.__unicode__()[0:25], extra)
         progress_info_s.send(sender=None, ptext=ptext, plen=ulen)
         for i, u in enumerate(updates):
             update = process_update(host, u, security)
@@ -132,7 +132,7 @@ def parse_updates(updates_string):
     updates = []
     ulist = updates_string.split()
     while ulist != []:
-        updates.append('%s %s %s\n' % (ulist[0], ulist[1], ulist[2]))
+        updates.append('{0!s} {1!s} {2!s}\n'.format(ulist[0], ulist[1], ulist[2]))
         ulist.pop(0)
         ulist.pop(0)
         ulist.pop(0)

--- a/patchman/reports/views.py
+++ b/patchman/reports/views.py
@@ -146,7 +146,7 @@ def report_delete(request, report):
     if request.method == 'POST':
         if 'delete' in request.REQUEST:
             report.delete()
-            messages.info(request, 'Report %s has been deleted' % report)
+            messages.info(request, 'Report {0!s} has been deleted'.format(report))
             return HttpResponseRedirect(reverse('report_list'))
         elif 'cancel' in request.REQUEST:
             return HttpResponseRedirect(reverse('report_detail',

--- a/patchman/repos/models.py
+++ b/patchman/repos/models.py
@@ -55,8 +55,8 @@ class Repository(models.Model):
     def show(self):
         """ Show info about this repo, including mirrors
         """
-        text = ['%s : %s\n' % (self.id, self.name),
-                'security: %s  arch: %s\n' % (self.security, self.arch),
+        text = ['{0!s} : {1!s}\n'.format(self.id, self.name),
+                'security: {0!s}  arch: {1!s}\n'.format(self.security, self.arch),
                 'Mirrors:\n']
 
         for line in text:
@@ -83,8 +83,7 @@ class Repository(models.Model):
             elif self.repotype == Repository.RPM:
                 refresh_rpm_repo(self)
             else:
-                text = 'Error: unknown repo type for repo %s: %s\n' % \
-                    (self.id, self.repotype)
+                text = 'Error: unknown repo type for repo {0!s}: {1!s}\n'.format(self.id, self.repotype)
                 error_message.send(sender=None, text=text)
         else:
             text = 'Repo requires certificate authentication, not updating\n'
@@ -138,9 +137,8 @@ class Mirror(models.Model):
         """ Show info about this mirror
         """
 
-        text = [' %s : %s\n' % (self.id, self.url),
-                ' last updated: %s    checksum: %s\n' %
-                (self.timestamp, self.file_checksum)]
+        text = [' {0!s} : {1!s}\n'.format(self.id, self.url),
+                ' last updated: {0!s}    checksum: {1!s}\n'.format(self.timestamp, self.file_checksum)]
 
         for line in text:
             info_message.send(sender=None, text=line)
@@ -150,7 +148,7 @@ class Mirror(models.Model):
             Disables refresh on a mirror if it fails more than 28 times
         """
 
-        text = 'No usable mirror found at %s\n' % self.url
+        text = 'No usable mirror found at {0!s}\n'.format(self.url)
         error_message.send(sender=None, text=text)
         self.fail_count = self.fail_count + 1
         if self.fail_count > 28:

--- a/patchman/repos/templatetags/patchman.py
+++ b/patchman/repos/templatetags/patchman.py
@@ -24,15 +24,15 @@ register = template.Library()
 def yes_no_button_repo_en(repo):
 
     if repo.enabled:
-        return '<button onclick="repo_endisable(0, \'' + str(repo.get_absolute_url()) + '\', this)"><img src="%s/img/admin/icon-yes.gif" alt="Enabled" /></button>' % settings.STATIC_URL
+        return '<button onclick="repo_endisable(0, \'' + str(repo.get_absolute_url()) + '\', this)"><img src="{0!s}/img/admin/icon-yes.gif" alt="Enabled" /></button>'.format(settings.STATIC_URL)
     else:
-        return '<button onclick="repo_endisable(1, \'' + str(repo.get_absolute_url()) + '\', this)"><img src="%s/img/admin/icon-no.gif" alt="Disabled" /></button>' % settings.STATIC_URL
+        return '<button onclick="repo_endisable(1, \'' + str(repo.get_absolute_url()) + '\', this)"><img src="{0!s}/img/admin/icon-no.gif" alt="Disabled" /></button>'.format(settings.STATIC_URL)
 
 
 @register.simple_tag
 def yes_no_button_repo_sec(repo):
 
     if repo.security:
-        return '<button onclick="repo_endisablesec(0, \'' + str(repo.get_absolute_url()) + '\', this)"><img src="%s/img/admin/icon-yes.gif" alt="Security" /></button>' % settings.STATIC_URL
+        return '<button onclick="repo_endisablesec(0, \'' + str(repo.get_absolute_url()) + '\', this)"><img src="{0!s}/img/admin/icon-yes.gif" alt="Security" /></button>'.format(settings.STATIC_URL)
     else:
-        return '<button onclick="repo_endisablesec(1, \'' + str(repo.get_absolute_url()) + '\', this)"><img src="%s/img/admin/icon-no.gif" alt="Non-Security" /></button>' % settings.STATIC_URL
+        return '<button onclick="repo_endisablesec(1, \'' + str(repo.get_absolute_url()) + '\', this)"><img src="{0!s}/img/admin/icon-no.gif" alt="Non-Security" /></button>'.format(settings.STATIC_URL)

--- a/patchman/repos/views.py
+++ b/patchman/repos/views.py
@@ -184,7 +184,7 @@ def mirror_list(request):
             repo.security = security
             repo.save()
             move_mirrors(repo)
-            text = 'Mirrors linked to new Repository %s' % repo
+            text = 'Mirrors linked to new Repository {0!s}'.format(repo)
             messages.info(request, text)
             return HttpResponseRedirect(repo.get_absolute_url())
 
@@ -192,7 +192,7 @@ def mirror_list(request):
         if link_form.is_valid():
             repo = link_form.cleaned_data['name']
             move_mirrors(repo)
-            messages.info(request, 'Mirrors linked to Repository %s' % repo)
+            messages.info(request, 'Mirrors linked to Repository {0!s}'.format(repo))
             return HttpResponseRedirect(repo.get_absolute_url())
 
     else:
@@ -246,7 +246,7 @@ def mirror_edit(request, repo_id, mirror_id):
         if edit_form.is_valid():
             mirror = edit_form.save()
             mirror.save()
-            messages.info(request, 'Saved changes to Mirror %s' % mirror)
+            messages.info(request, 'Saved changes to Mirror {0!s}'.format(mirror))
         else:
             mirror = get_object_or_404(Mirror, id=mirror_id)
     else:
@@ -285,7 +285,7 @@ def repo_edit(request, repo_id):
                 repo.enable()
             else:
                 repo.disable()
-            messages.info(request, 'Saved changes to Repository %s' % repo)
+            messages.info(request, 'Saved changes to Repository {0!s}'.format(repo))
             return HttpResponseRedirect(repo.get_absolute_url())
         else:
             repo = get_object_or_404(Repository, id=repo_id)
@@ -308,7 +308,7 @@ def repo_delete(request, repo_id):
             for mirror in repo.mirror_set.all():
                 mirror.delete()
             repo.delete()
-            messages.info(request, 'Repository %s has been deleted' % repo)
+            messages.info(request, 'Repository {0!s} has been deleted'.format(repo))
             return HttpResponseRedirect(reverse('repo_list'))
         elif 'cancel' in request.REQUEST:
             return HttpResponseRedirect(reverse('repo_detail', args=[repo_id]))
@@ -330,7 +330,7 @@ def repo_enable(request, repo_id):
             if request.is_ajax():
                 return HttpResponse(status=204)
             else:
-                text = 'Repository %s has been enabled' % repo
+                text = 'Repository {0!s} has been enabled'.format(repo)
                 messages.info(request, text)
                 return HttpResponseRedirect(reverse('repo_detail',
                                                     args=[repo_id]))
@@ -355,7 +355,7 @@ def repo_disable(request, repo_id):
             if request.is_ajax():
                 return HttpResponse(status=204)
             else:
-                text = 'Repository %s has been disabled' % repo
+                text = 'Repository {0!s} has been disabled'.format(repo)
                 messages.info(request, text)
                 return HttpResponseRedirect(
                     reverse('repo_detail', args=[repo_id]))
@@ -380,7 +380,7 @@ def repo_enablesec(request, repo_id):
             if request.is_ajax():
                 return HttpResponse(status=204)
             else:
-                text = 'Repository %s has been marked as a security' % repo
+                text = 'Repository {0!s} has been marked as a security'.format(repo)
                 text += ' repo'
                 messages.info(request, text)
                 return HttpResponseRedirect(reverse('repo_detail',
@@ -406,7 +406,7 @@ def repo_disablesec(request, repo_id):
             if request.is_ajax():
                 return HttpResponse(status=204)
             else:
-                text = 'Repository %s has been marked as a non-security' % repo
+                text = 'Repository {0!s} has been marked as a non-security'.format(repo)
                 text += ' repo'
                 messages.info(request, text)
                 return HttpResponseRedirect(reverse('repo_detail',

--- a/patchman/util/__init__.py
+++ b/patchman/util/__init__.py
@@ -77,7 +77,7 @@ def download_url(res, text=''):
             try:
                 chunk = res.read(int(chunk_size))
             except socket.timeout as e:
-                print 'socket.timeout: %s' % e
+                print 'socket.timeout: {0!s}'.format(e)
                 return
             i += len(chunk)
             update_pbar(i)

--- a/patchman/util/filterspecs.py
+++ b/patchman/util/filterspecs.py
@@ -22,7 +22,7 @@ import datetime
 from operator import itemgetter
 
 def get_query_string(qs):
-    return '?' + '&amp;'.join([u'%s=%s' % (k, v) for k, v in qs.items()]).replace(' ', '%20')
+    return '?' + '&amp;'.join([u'{0!s}={1!s}'.format(k, v) for k, v in qs.items()]).replace(' ', '%20')
 
 class Filter(object):
     multi = False
@@ -64,21 +64,21 @@ class Filter(object):
             pass
 
         output = ''
-        output += '<h3>By %s</h3>\n' % self.header.replace('_', ' ')
+        output += '<h3>By {0!s}</h3>\n'.format(self.header.replace('_', ' '))
         output += '<ul>\n'
         filters = sorted(self.filters.iteritems(), key=itemgetter(1))
 
         if self.selected is not None:
-            output += """<li><a href="%s">All</a></li>\n""" % get_query_string(qs)
+            output += """<li><a href="{0!s}">All</a></li>\n""".format(get_query_string(qs))
         else:
-            output += """<li class="selected"><a href="%s">All</a></li>\n""" % get_query_string(qs)
+            output += """<li class="selected"><a href="{0!s}">All</a></li>\n""".format(get_query_string(qs))
         for k, v in filters:
             if str(self.selected) == str(k):
                 style = """class="selected" """
             else:
                 style = ""
             qs[self.name] = k
-            output += """<li %s><a href="%s">%s</a></li>\n""" % (style, get_query_string(qs), v)
+            output += """<li {0!s}><a href="{1!s}">{2!s}</a></li>\n""".format(style, get_query_string(qs), v)
 
         output += '</ul>'
 
@@ -98,7 +98,7 @@ class DateFilter(object):
             self.header = header
         params = dict(request.GET.items())
 
-        self.field_generic = '%s__' % self.name
+        self.field_generic = '{0!s}__'.format(self.name)
 
         self.date_params = dict([(k, v) for k, v in params.items() if k.startswith(self.field_generic)])
 
@@ -108,14 +108,14 @@ class DateFilter(object):
 
         self.links = (
             ('Any date', {}),
-            ('Today', {'%s__year' % self.name: str(today.year),
-                       '%s__month' % self.name: str(today.month),
-                       '%s__day' % self.name: str(today.day)}),
-            ('Past 7 days', {'%s__gte' % self.name: one_week_ago.strftime('%Y-%m-%d'),
-                             '%s__lte' % self.name: today_str}),
-            ('This month', {'%s__year' % self.name: str(today.year),
-                             '%s__month' % self.name: str(today.month)}),
-            ('This year', {'%s__year' % self.name: str(today.year)})
+            ('Today', {'{0!s}__year'.format(self.name): str(today.year),
+                       '{0!s}__month'.format(self.name): str(today.month),
+                       '{0!s}__day'.format(self.name): str(today.day)}),
+            ('Past 7 days', {'{0!s}__gte'.format(self.name): one_week_ago.strftime('%Y-%m-%d'),
+                             '{0!s}__lte'.format(self.name): today_str}),
+            ('This month', {'{0!s}__year'.format(self.name): str(today.year),
+                             '{0!s}__month'.format(self.name): str(today.month)}),
+            ('This year', {'{0!s}__year'.format(self.name): str(today.year)})
         )
 
     def choices(self):
@@ -129,7 +129,7 @@ class DateFilter(object):
         choices = self.choices()
 
         output = ''
-        output += '<h3>By %s</h3>\n' % self.header.replace('_', ' ')
+        output += '<h3>By {0!s}</h3>\n'.format(self.header.replace('_', ' '))
         output += '<ul>\n'
 
 
@@ -141,7 +141,7 @@ class DateFilter(object):
             for k,v in choice['query_dict'].items():
                 qs[k] = v
 
-            output += """<li %s><a href="%s">%s</a></li>\n""" % (choice['selected'] and "class='selected'" or '', get_query_string(qs), choice['display'])
+            output += """<li {0!s}><a href="{1!s}">{2!s}</a></li>\n""".format(choice['selected'] and "class='selected'" or '', get_query_string(qs), choice['display'])
 
         output += '</ul>'
         return output
@@ -165,7 +165,7 @@ class FilterBar(object):
         for f in self.filter_list:
             if f.multi:
                 params = dict(request.GET.items())
-                field_generic = '%s__' % f.name
+                field_generic = '{0!s}__'.format(f.name)
                 m_params = dict([(k, v) for k, v in params.items() if k.startswith(field_generic)])
                 for k,v in m_params.items():
                     qs[k] = v

--- a/patchman/util/templatetags/common.py
+++ b/patchman/util/templatetags/common.py
@@ -26,7 +26,7 @@ register = template.Library()
 @register.simple_tag
 def active(request, pattern):
     import re
-    if re.search('^%s/%s' % (request.META['SCRIPT_NAME'], pattern), request.path):
+    if re.search('^{0!s}/{1!s}'.format(request.META['SCRIPT_NAME'], pattern), request.path):
         return 'active'
     return ''
 
@@ -56,18 +56,18 @@ def date_filter(start, end):
     if view_7:
         s += 'Last 7 Days'
     else:
-        s += """<a href="./?start=%s">Last 7 Days</a>""" % last_7
+        s += """<a href="./?start={0!s}">Last 7 Days</a>""".format(last_7)
     s += " | "
 
     if view_90:
         s += "Last 90 Days"
     else:
-        s += """<a href="./?start=%s">Last 90 Days</a>""" % last_90
+        s += """<a href="./?start={0!s}">Last 90 Days</a>""".format(last_90)
     s += " | "
     if view_365:
         s += "Last 365 Days"
     else:
-        s += """<a href="./?start=%s">Last 365 Days</a>""" % last_365
+        s += """<a href="./?start={0!s}">Last 365 Days</a>""".format(last_365)
 
 
     return s
@@ -83,9 +83,9 @@ def yes_no_img(boolean, reversed=False, alt_true='Active', alt_false='Not Active
             boolean = True
 
     if boolean:
-        return """<img src="%simg/admin/icon-yes.gif" alt="%s" />""" % (settings.STATIC_URL, alt_true)
+        return """<img src="{0!s}img/admin/icon-yes.gif" alt="{1!s}" />""".format(settings.STATIC_URL, alt_true)
     else:
-        return """<img src="%simg/admin/icon-no.gif" alt="%s"/>""" % (settings.STATIC_URL, alt_false)
+        return """<img src="{0!s}img/admin/icon-no.gif" alt="{1!s}"/>""".format(settings.STATIC_URL, alt_false)
 
 
 
@@ -98,7 +98,7 @@ def searchform(parser, token):
             tag_name = token.split_contents()
             post_url = '.'
         except:
-            raise template.TemplateSyntaxError, "%r tag requires one or no arguments" % token.contents.split()[0]
+            raise template.TemplateSyntaxError, "{0!r} tag requires one or no arguments".format(token.contents.split()[0])
     return SearchFormNode(post_url)
 
 class SearchFormNode(template.Node):
@@ -122,7 +122,7 @@ def gen_table(parser, token):
             tag_name, queryset = token.split_contents()
             template_name = None
         except:
-            raise template.TemplateSyntaxError, "%r tag requires one or two arguments" % token.contents.split()[0]
+            raise template.TemplateSyntaxError, "{0!r} tag requires one or two arguments".format(token.contents.split()[0])
     return QuerySetTableNode(queryset, template_name)
 
 
@@ -141,7 +141,7 @@ class QuerySetTableNode(template.Node):
         if not self.template_name:
             app_label = queryset.model._meta.app_label
             model_name = queryset.model._meta.verbose_name
-            template_name = '%s/%s_table.html' % (app_label, model_name.lower().replace(' ', ''))
+            template_name = '{0!s}/{1!s}_table.html'.format(app_label, model_name.lower().replace(' ', ''))
         else:
             template_name  = self.template_name
         template_obj = template.loader.get_template(template_name)

--- a/patchman/util/templatetags/forms.py
+++ b/patchman/util/templatetags/forms.py
@@ -45,7 +45,7 @@ def formfield(parser, token):
     try:
         tag_name, field = token.split_contents()
     except:
-        raise template.TemplateSyntaxError, "%r tag requires exactly one argument" % token.contents.split()[0]
+        raise template.TemplateSyntaxError, "{0!r} tag requires exactly one argument".format(token.contents.split()[0])
     return FormFieldNode(field)
 
 
@@ -55,7 +55,7 @@ class FormFieldNode(template.Node):
 
     def get_template(self, class_name):
         try:
-            template_name = 'formfield/%s.html' % class_name
+            template_name = 'formfield/{0!s}.html'.format(class_name)
             return template.loader.get_template(template_name)
         except template.TemplateDoesNotExist:
             return template.loader.get_template('formfield/default.html')
@@ -75,7 +75,7 @@ class FormFieldNode(template.Node):
             label_class_names.append('vCheckboxLabel')
 
 
-        class_str = label_class_names and u' class="%s"' % u' '.join(label_class_names) or u''
+        class_str = label_class_names and u' class="{0!s}"'.format(u' '.join(label_class_names)) or u''
 
         context.push()
         context.push()

--- a/patchman/util/templatetags/paginator.py
+++ b/patchman/util/templatetags/paginator.py
@@ -32,9 +32,9 @@ def paginator_number(page, i, qs):
     if i == DOT:
         return u'... '
     elif i == page.number:
-        return mark_safe(u'<span class="this-page">%d</span> ' % (i))
+        return mark_safe(u'<span class="this-page">{0:d}</span> '.format((i)))
     else:
-        return mark_safe(u'<a href="%s"%s>%d</a> ' % ((get_query_string(qs)), (i == page.paginator.num_pages and ' class="end"' or ''), i))
+        return mark_safe(u'<a href="{0!s}"{1!s}>{2:d}</a> '.format((get_query_string(qs)), (i == page.paginator.num_pages and ' class="end"' or ''), i))
 paginator_number = register.simple_tag(paginator_number)
 
 def pagination(page, request, eitherside=10):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:furlongm:patchman?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:furlongm:patchman?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)