### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/hooks/yum/patchman.py
+++ b/hooks/yum/patchman.py
@@ -10,5 +10,5 @@ def posttrans_hook(conduit):
     conduit.info(2, 'patchman: sending data')
     servicecmd = conduit.confString('main', 'servicecmd', '/usr/sbin/patchman-client')
     args = '-n'
-    command = '%s %s> /dev/null' % (servicecmd, args)
+    command = '{0!s} {1!s}> /dev/null'.format(servicecmd, args)
     os.system(command)

--- a/patchman/hosts/models.py
+++ b/patchman/hosts/models.py
@@ -60,21 +60,21 @@ class Host(models.Model):
     def show(self):
         """ Show info about this host
         """
-        text = '%s:\n' % self
-        text += 'IP address   : %s\n' % self.ipaddress
-        text += 'Reverse DNS  : %s\n' % self.reversedns
-        text += 'Domain       : %s\n' % self.domain
-        text += 'OS           : %s\n' % self.os
-        text += 'Kernel       : %s\n' % self.kernel
-        text += 'Architecture : %s\n' % self.arch
-        text += 'Last report  : %s\n' % self.lastreport
-        text += 'Packages     : %s\n' % self.get_num_packages()
-        text += 'Repos        : %s\n' % self.get_num_repos()
-        text += 'Updates      : %s\n' % self.get_num_updates()
-        text += 'Tags         : %s\n' % self.tags
-        text += 'Needs reboot : %s\n' % self.reboot_required
-        text += 'Updated at   : %s\n' % self.updated_at
-        text += 'Host repos   : %s\n' % self.host_repos_only
+        text = '{0!s}:\n'.format(self)
+        text += 'IP address   : {0!s}\n'.format(self.ipaddress)
+        text += 'Reverse DNS  : {0!s}\n'.format(self.reversedns)
+        text += 'Domain       : {0!s}\n'.format(self.domain)
+        text += 'OS           : {0!s}\n'.format(self.os)
+        text += 'Kernel       : {0!s}\n'.format(self.kernel)
+        text += 'Architecture : {0!s}\n'.format(self.arch)
+        text += 'Last report  : {0!s}\n'.format(self.lastreport)
+        text += 'Packages     : {0!s}\n'.format(self.get_num_packages())
+        text += 'Repos        : {0!s}\n'.format(self.get_num_repos())
+        text += 'Updates      : {0!s}\n'.format(self.get_num_updates())
+        text += 'Tags         : {0!s}\n'.format(self.tags)
+        text += 'Needs reboot : {0!s}\n'.format(self.reboot_required)
+        text += 'Updated at   : {0!s}\n'.format(self.updated_at)
+        text += 'Host repos   : {0!s}\n'.format(self.host_repos_only)
 
         info_message.send(sender=None, text=text)
 
@@ -104,8 +104,7 @@ class Host(models.Model):
                 info_message.send(sender=None, text='Reverse DNS matches')
             else:
                 info_message.send(sender=None,
-                                  text='Reverse DNS mismatch found: %s != %s'
-                                  % (self.hostname, self.reversedns))
+                                  text='Reverse DNS mismatch found: {0!s} != {1!s}'.format(self.hostname, self.reversedns))
         else:
             info_message.send(sender=None,
                               text='Reverse DNS check disabled')
@@ -158,7 +157,7 @@ class Host(models.Model):
         try:
             with transaction.atomic():
                 self.updates.add(update)
-            info_message.send(sender=None, text="%s" % update)
+            info_message.send(sender=None, text="{0!s}".format(update))
             return update.id
         except IntegrityError as e:
             error_message.send(sender=None, text=e)
@@ -336,4 +335,4 @@ class HostRepo(models.Model):
         unique_together = ('host', 'repo')
 
     def __unicode__(self):
-        return '%s-%s' % (self.host, self.repo)
+        return '{0!s}-{1!s}'.format(self.host, self.repo)

--- a/patchman/hosts/south_migrations/0004_auto__add_unique_hostrepo_repo_host.py
+++ b/patchman/hosts/south_migrations/0004_auto__add_unique_hostrepo_repo_host.py
@@ -15,7 +15,7 @@ class Migration(SchemaMigration):
             # Remove existing duplicates
             hostrepos = []
             for hostrepo in orm.HostRepo.objects.all():
-                hr_string = '%s-%s' % (hostrepo.host.id, hostrepo.repo.id)
+                hr_string = '{0!s}-{1!s}'.format(hostrepo.host.id, hostrepo.repo.id)
                 if hr_string in hostrepos:
                     hostrepo.delete()
                 else:

--- a/patchman/hosts/utils.py
+++ b/patchman/hosts/utils.py
@@ -54,7 +54,7 @@ def remove_reports(host, timestamp):
     del_reports = Report.objects.filter(host=host).exclude(id__in=report_ids)
 
     rlen = del_reports.count()
-    ptext = 'Cleaning %s old reports' % rlen
+    ptext = 'Cleaning {0!s} old reports'.format(rlen)
     progress_info_s.send(sender=None, ptext=ptext, plen=rlen)
     for i, report in enumerate(del_reports):
         report.delete()

--- a/patchman/hosts/views.py
+++ b/patchman/hosts/views.py
@@ -135,7 +135,7 @@ def host_edit(request, hostname):
             if edit_form.is_valid():
                 host = edit_form.save()
                 host.save()
-                messages.info(request, 'Saved changes to Host %s' % host)
+                messages.info(request, 'Saved changes to Host {0!s}'.format(host))
                 return HttpResponseRedirect(host.get_absolute_url())
             else:
                 host = get_object_or_404(Host, hostname=hostname)
@@ -160,7 +160,7 @@ def host_delete(request, hostname):
     if request.method == 'POST':
         if 'delete' in request.POST:
             host.delete()
-            messages.info(request, 'Host %s has been deleted' % hostname)
+            messages.info(request, 'Host {0!s} has been deleted'.format(hostname))
             return HttpResponseRedirect(reverse('host_list'))
         elif 'cancel' in request.POST:
             return HttpResponseRedirect(reverse('host_detail',

--- a/patchman/operatingsystems/views.py
+++ b/patchman/operatingsystems/views.py
@@ -70,13 +70,13 @@ def os_detail(request, os_id):
             osgroup = create_form.save()
             os.osgroup = osgroup
             os.save()
-            text = 'Created OS Group %s and added OS %s to it' % (osgroup, os)
+            text = 'Created OS Group {0!s} and added OS {1!s} to it'.format(osgroup, os)
             messages.info(request, text)
             return HttpResponseRedirect(os.get_absolute_url())
         add_form = AddOSToOSGroupForm(request.POST, instance=os, prefix='add')
         if add_form.is_valid():
             add_form.save()
-            text = 'OS %s added to OS Group %s' % (os, os.osgroup)
+            text = 'OS {0!s} added to OS Group {1!s}'.format(os, os.osgroup)
             messages.info(request, text)
             return HttpResponseRedirect(os.get_absolute_url())
     else:
@@ -104,7 +104,7 @@ def os_delete(request, os_id):
         if 'delete' in request.POST:
             if os:
                 os.delete()
-                messages.info(request, 'OS %s has been deleted' % os)
+                messages.info(request, 'OS {0!s} has been deleted'.format(os))
                 return HttpResponseRedirect(reverse('os_list'))
             else:
                 if not oses:
@@ -113,7 +113,7 @@ def os_delete(request, os_id):
                     return HttpResponseRedirect(reverse('os_list'))
                 for os in oses:
                     os.delete()
-                text = '%s OS\'s have been deleted' % len(oses)
+                text = '{0!s} OS\'s have been deleted'.format(len(oses))
                 messages.info(request, text)
                 return HttpResponseRedirect(reverse('os_list'))
         elif 'cancel' in request.POST:
@@ -184,7 +184,7 @@ def osgroup_delete(request, osgroup_id):
     if request.method == 'POST':
         if 'delete' in request.POST:
             osgroup.delete()
-            messages.info(request, 'OS Group %s has been deleted' % osgroup)
+            messages.info(request, 'OS Group {0!s} has been deleted'.format(osgroup))
             return HttpResponseRedirect(reverse('os_list'))
         elif 'cancel' in request.POST:
             oid = osgroup_id

--- a/patchman/packages/models.py
+++ b/patchman/packages/models.py
@@ -73,14 +73,14 @@ class Package(models.Model):
 
     def __unicode__(self):
         if self.epoch:
-            epo = '%s:' % self.epoch
+            epo = '{0!s}:'.format(self.epoch)
         else:
             epo = ''
         if self.release:
-            rel = '-%s' % self.release
+            rel = '-{0!s}'.format(self.release)
         else:
             rel = ''
-        return '%s-%s%s%s-%s' % (self.name, epo, self.version, rel, self.arch)
+        return '{0!s}-{1!s}{2!s}{3!s}-{4!s}'.format(self.name, epo, self.version, rel, self.arch)
 
     def get_absolute_url(self):
         return self.name.get_absolute_url()
@@ -152,14 +152,14 @@ class PackageString(models.Model):
 
     def __unicode__(self):
         if self.epoch:
-            epo = '%s:' % self.epoch
+            epo = '{0!s}:'.format(self.epoch)
         else:
             epo = ''
         if self.release:
-            rel = '-%s' % self.release
+            rel = '-{0!s}'.format(self.release)
         else:
             rel = ''
-        return '%s-%s%s%s-%s' % (self.name, epo, self.version, rel, self.arch)
+        return '{0!s}-{1!s}{2!s}{3!s}-{4!s}'.format(self.name, epo, self.version, rel, self.arch)
 
     def __key(self):
         return (self.name, self.epoch, self.version, self.release, self.arch,
@@ -191,5 +191,5 @@ class PackageUpdate(models.Model):
             update_type = 'Security'
         else:
             update_type = 'Bugfix'
-        return '%s -> %s (%s)' % (self.oldpackage, self.newpackage,
+        return '{0!s} -> {1!s} ({2!s})'.format(self.oldpackage, self.newpackage,
                                   update_type)

--- a/patchman/packages/utils.py
+++ b/patchman/packages/utils.py
@@ -49,12 +49,12 @@ def find_version(s, epoch, release):
     """ Given a package version string, return the version """
 
     try:
-        es = '%s:' % epoch
+        es = '{0!s}:'.format(epoch)
         e = s.index(es) + len(epoch) + 1
     except ValueError:
         e = 0
     try:
-        rs = '-%s' % release
+        rs = '-{0!s}'.format(release)
         r = s.index(rs)
     except ValueError:
         r = len(s)

--- a/patchman/reports/models.py
+++ b/patchman/reports/models.py
@@ -51,7 +51,7 @@ class Report(models.Model):
         ordering = ('-created',)
 
     def __unicode__(self):
-        return '%s %s' % (self.host, self.created)
+        return '{0!s} {1!s}'.format(self.host, self.created)
 
     @models.permalink
     def get_absolute_url(self):
@@ -136,7 +136,7 @@ class Report(models.Model):
             host.check_rdns()
 
             if verbose:
-                text = 'Processing report %s - %s' % (self.id, self.host)
+                text = 'Processing report {0!s} - {1!s}'.format(self.id, self.host)
                 info_message.send(sender=None, text=text)
 
             from patchman.reports.utils import process_packages, \
@@ -154,15 +154,14 @@ class Report(models.Model):
 
             if find_updates:
                 if verbose:
-                    text = 'Finding updates for report %s - %s' % (self.id,
+                    text = 'Finding updates for report {0!s} - {1!s}'.format(self.id,
                                                                    self.host)
                     info_message.send(sender=None, text=text)
                 host.find_updates()
         else:
             if self.processed:
-                text = 'Report %s has already been processed\n' % (self.id)
+                text = 'Report {0!s} has already been processed\n'.format((self.id))
                 info_message.send(sender=None, text=text)
             else:
-                text = 'Error: OS, kernel or arch not sent with report %s\n' \
-                    % (self.id)
+                text = 'Error: OS, kernel or arch not sent with report {0!s}\n'.format((self.id))
                 error_message.send(sender=None, text=text)

--- a/patchman/reports/utils.py
+++ b/patchman/reports/utils.py
@@ -38,7 +38,7 @@ def process_repos(report, host):
 
         repos = parse_repos(report.repos)
         progress_info_s.send(sender=None,
-                             ptext='%s repos' % host.__unicode__()[0:25],
+                             ptext='{0!s} repos'.format(host.__unicode__()[0:25]),
                              plen=len(repos))
         for i, repo_str in enumerate(repos):
             repo, priority = process_repo(repo_str, report.arch)
@@ -74,7 +74,7 @@ def process_packages(report, host):
 
         packages = parse_packages(report.packages)
         progress_info_s.send(sender=None,
-                             ptext='%s packages' % host.__unicode__()[0:25],
+                             ptext='{0!s} packages'.format(host.__unicode__()[0:25]),
                              plen=len(packages))
         for i, pkg_str in enumerate(packages):
             package = process_package(pkg_str, report.protocol)
@@ -89,7 +89,7 @@ def process_packages(report, host):
                     error_message.send(sender=None, text=e)
             else:
                 if pkg_str[0].lower() != 'gpg-pubkey':
-                    text = 'No package returned for %s' % pkg_str
+                    text = 'No package returned for {0!s}'.format(pkg_str)
                     info_message.send(sender=None, text=text)
             progress_update_s.send(sender=None, index=i + 1)
 
@@ -120,7 +120,7 @@ def add_updates(updates, host, security):
         extra = 'bug'
 
     if ulen > 0:
-        ptext = '%s %s updates' % (host.__unicode__()[0:25], extra)
+        ptext = '{0!s} {1!s} updates'.format(host.__unicode__()[0:25], extra)
         progress_info_s.send(sender=None, ptext=ptext, plen=ulen)
         for i, u in enumerate(updates):
             update = process_update(host, u, security)
@@ -135,7 +135,7 @@ def parse_updates(updates_string):
     updates = []
     ulist = updates_string.split()
     while ulist != []:
-        updates.append('%s %s %s\n' % (ulist[0], ulist[1], ulist[2]))
+        updates.append('{0!s} {1!s} {2!s}\n'.format(ulist[0], ulist[1], ulist[2]))
         ulist.pop(0)
         ulist.pop(0)
         ulist.pop(0)

--- a/patchman/reports/views.py
+++ b/patchman/reports/views.py
@@ -143,7 +143,7 @@ def report_delete(request, report):
     if request.method == 'POST':
         if 'delete' in request.POST:
             report.delete()
-            messages.info(request, 'Report %s has been deleted' % report)
+            messages.info(request, 'Report {0!s} has been deleted'.format(report))
             return HttpResponseRedirect(reverse('report_list'))
         elif 'cancel' in request.POST:
             return HttpResponseRedirect(reverse('report_detail',

--- a/patchman/repos/models.py
+++ b/patchman/repos/models.py
@@ -56,8 +56,8 @@ class Repository(models.Model):
     def show(self):
         """ Show info about this repo, including mirrors
         """
-        text = '%s : %s\n' % (self.id, self.name)
-        text += 'security: %s  arch: %s\n' % (self.security, self.arch)
+        text = '{0!s} : {1!s}\n'.format(self.id, self.name)
+        text += 'security: {0!s}  arch: {1!s}\n'.format(self.security, self.arch)
         text += 'Mirrors:'
 
         info_message.send(sender=None, text=text)
@@ -81,8 +81,7 @@ class Repository(models.Model):
             elif self.repotype == Repository.RPM:
                 refresh_rpm_repo(self)
             else:
-                text = 'Error: unknown repo type for repo %s: %s\n' % \
-                    (self.id, self.repotype)
+                text = 'Error: unknown repo type for repo {0!s}: {1!s}\n'.format(self.id, self.repotype)
                 error_message.send(sender=None, text=text)
         else:
             text = 'Repo requires certificate authentication, not updating\n'
@@ -143,8 +142,8 @@ class Mirror(models.Model):
         """ Show info about this mirror
         """
 
-        text = ' %s : %s\n' % (self.id, self.url)
-        text += ' last updated: %s    checksum: %s\n' % (self.timestamp,
+        text = ' {0!s} : {1!s}\n'.format(self.id, self.url)
+        text += ' last updated: {0!s}    checksum: {1!s}\n'.format(self.timestamp,
                                                          self.file_checksum)
 
         info_message.send(sender=None, text=text)
@@ -154,7 +153,7 @@ class Mirror(models.Model):
             Disables refresh on a mirror if it fails more than 28 times
         """
 
-        text = 'No usable mirror found at %s\n' % self.url
+        text = 'No usable mirror found at {0!s}\n'.format(self.url)
         error_message.send(sender=None, text=text)
         self.fail_count = self.fail_count + 1
         if self.fail_count > 28:

--- a/patchman/repos/views.py
+++ b/patchman/repos/views.py
@@ -186,7 +186,7 @@ def mirror_list(request):
             repo.security = security
             repo.save()
             move_mirrors(repo)
-            text = 'Mirrors linked to new Repository %s' % repo
+            text = 'Mirrors linked to new Repository {0!s}'.format(repo)
             messages.info(request, text)
             return HttpResponseRedirect(repo.get_absolute_url())
 
@@ -194,7 +194,7 @@ def mirror_list(request):
         if link_form.is_valid():
             repo = link_form.cleaned_data['name']
             move_mirrors(repo)
-            messages.info(request, 'Mirrors linked to Repository %s' % repo)
+            messages.info(request, 'Mirrors linked to Repository {0!s}'.format(repo))
             return HttpResponseRedirect(repo.get_absolute_url())
     else:
         if 'checksum' in request.GET and mirrors:
@@ -232,7 +232,7 @@ def mirror_delete(request, mirror_id):
     if request.method == 'POST':
         if 'delete' in request.POST:
             mirror.delete()
-            messages.info(request, 'Mirror %s has been deleted' % mirror)
+            messages.info(request, 'Mirror {0!s} has been deleted'.format(mirror))
             return HttpResponseRedirect(reverse('mirror_list'))
         elif 'cancel' in request.POST:
             return HttpResponseRedirect(reverse('mirror_detail',
@@ -254,7 +254,7 @@ def mirror_edit(request, mirror_id):
             if edit_form.is_valid():
                 mirror = edit_form.save()
                 mirror.save()
-                messages.info(request, 'Saved changes to Mirror %s' % mirror)
+                messages.info(request, 'Saved changes to Mirror {0!s}'.format(mirror))
                 return HttpResponseRedirect(mirror.get_absolute_url())
             else:
                 mirror = get_object_or_404(Mirror, id=mirror_id)
@@ -298,7 +298,7 @@ def repo_edit(request, repo_id):
                     repo.enable()
                 else:
                     repo.disable()
-                messages.info(request, 'Saved changes to Repository %s' % repo)
+                messages.info(request, 'Saved changes to Repository {0!s}'.format(repo))
                 return HttpResponseRedirect(repo.get_absolute_url())
             else:
                 repo = get_object_or_404(Repository, id=repo_id)
@@ -324,7 +324,7 @@ def repo_delete(request, repo_id):
             for mirror in repo.mirror_set.all():
                 mirror.delete()
             repo.delete()
-            messages.info(request, 'Repository %s has been deleted' % repo)
+            messages.info(request, 'Repository {0!s} has been deleted'.format(repo))
             return HttpResponseRedirect(reverse('repo_list'))
         elif 'cancel' in request.POST:
             return HttpResponseRedirect(reverse('repo_detail', args=[repo_id]))
@@ -348,7 +348,7 @@ def repo_toggle_enabled(request, repo_id):
     if request.is_ajax():
         return HttpResponse(status=204)
     else:
-        text = 'Repository %s has been %s' % (repo, status)
+        text = 'Repository {0!s} has been {1!s}'.format(repo, status)
         messages.info(request, text)
         return HttpResponseRedirect(reverse('repo_detail',
                                             args=[repo_id]))
@@ -368,8 +368,7 @@ def repo_toggle_security(request, repo_id):
     if request.is_ajax():
         return HttpResponse(status=204)
     else:
-        text = 'Repository %s has been marked as a %s update repo' \
-               % (repo, sectype)
+        text = 'Repository {0!s} has been marked as a {1!s} update repo'.format(repo, sectype)
         messages.info(request, text)
         return HttpResponseRedirect(reverse('repo_detail',
                                             args=[repo_id]))

--- a/patchman/util/filterspecs.py
+++ b/patchman/util/filterspecs.py
@@ -22,7 +22,7 @@ from operator import itemgetter
 
 
 def get_query_string(qs):
-    newqs = [u'%s=%s' % (k, v) for k, v in qs.items()]
+    newqs = [u'{0!s}={1!s}'.format(k, v) for k, v in qs.items()]
     return '?' + '&amp;'.join(newqs).replace(' ', '%20')
 
 
@@ -61,18 +61,15 @@ class Filter(object):
 
         output = ''
         output += '<div class="panel panel-default">\n'
-        output += '<div class="panel-heading">%s</div>\n' \
-                  % self.header.replace('_', ' ')
+        output += '<div class="panel-heading">{0!s}</div>\n'.format(self.header.replace('_', ' '))
         output += '<div class="panel-body">\n'
         output += '<div class="list-group list-group-info">\n'
         filters = sorted(self.filters.iteritems(), key=itemgetter(1))
 
         if self.selected is not None:
-            output += '<a href="%s" class="list-group-item">all</a>\n' \
-                      % get_query_string(qs)
+            output += '<a href="{0!s}" class="list-group-item">all</a>\n'.format(get_query_string(qs))
         else:
-            output += '<a href="%s" class="list-group-item ' \
-                      % get_query_string(qs)
+            output += '<a href="{0!s}" class="list-group-item '.format(get_query_string(qs))
             output += 'list-group-item-success">all</a>\n'
         for k, v in filters:
             if str(self.selected) == str(k):
@@ -80,8 +77,7 @@ class Filter(object):
             else:
                 style = ''
             qs[self.name] = k
-            output += '<a href="%s" class="list-group-item %s">%s</a>\n' \
-                      % (get_query_string(qs), style, v)
+            output += '<a href="{0!s}" class="list-group-item {1!s}">{2!s}</a>\n'.format(get_query_string(qs), style, v)
         output += '</div></div></div>'
         return output
 
@@ -104,7 +100,7 @@ class FilterBar(object):
         for f in self.filter_list:
             if f.multi:
                 params = dict(request.GET.items())
-                generic = '%s__' % f.name
+                generic = '{0!s}__'.format(f.name)
                 m_params = \
                 {k: v for k, v in params.items() if k.startswith(generic)}
                 for k, v in m_params.items():

--- a/patchman/util/templatetags/common.py
+++ b/patchman/util/templatetags/common.py
@@ -29,7 +29,7 @@ register = Library()
 @register.simple_tag
 def active(request, pattern):
     import re
-    if re.search('^%s/%s' % (request.META['SCRIPT_NAME'], pattern),
+    if re.search('^{0!s}/{1!s}'.format(request.META['SCRIPT_NAME'], pattern),
                  request.path):
         return 'active'
     return ''
@@ -40,9 +40,9 @@ def yes_no_img(boolean, alt_yes='Active', alt_no='Not Active'):
     yes_icon = static('img/icon-yes.gif')
     no_icon = static('img/icon-no.gif')
     if boolean:
-        html = "<img src='%s' alt='%s' />" % (yes_icon, alt_yes)
+        html = "<img src='{0!s}' alt='{1!s}' />".format(yes_icon, alt_yes)
     else:
-        html = "<img src='%s' alt='%s' />" % (no_icon, alt_no)
+        html = "<img src='{0!s}' alt='{1!s}' />".format(no_icon, alt_no)
     return format_html(html)
 
 
@@ -51,9 +51,9 @@ def no_yes_img(boolean, alt_yes='Not Required', alt_no='Required'):
     yes_icon = static('img/icon-yes.gif')
     no_icon = static('img/icon-no.gif')
     if not boolean:
-        html = "<img src='%s' alt='%s' />" % (yes_icon, alt_yes)
+        html = "<img src='{0!s}' alt='{1!s}' />".format(yes_icon, alt_yes)
     else:
-        html = "<img src='%s' alt='%s' />" % (no_icon, alt_no)
+        html = "<img src='{0!s}' alt='{1!s}' />".format(no_icon, alt_no)
     return format_html(html)
 
 
@@ -64,8 +64,7 @@ def gen_table(object_list, template_name=None):
     if not template_name:
         app_label = object_list.model._meta.app_label
         model_name = object_list.model._meta.verbose_name
-        template_name = '%s/%s_table.html' % \
-            (app_label, model_name.lower().replace(' ', ''))
+        template_name = '{0!s}/{1!s}_table.html'.format(app_label, model_name.lower().replace(' ', ''))
     template = get_template(template_name)
     html = template.render({'object_list': object_list})
     return html
@@ -78,7 +77,7 @@ def object_count(page):
             name = page.paginator.object_list.model._meta.verbose_name
         else:
             name = page.paginator.object_list.model._meta.verbose_name_plural
-    return '%s %s' % (page.paginator.count, name)
+    return '{0!s} {1!s}'.format(page.paginator.count, name)
 
 
 @register.assignment_tag


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:furlongm:patchman?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:furlongm:patchman?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)