### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/hooks/zypper/patchman.py
+++ b/hooks/zypper/patchman.py
@@ -27,12 +27,12 @@ class MyPlugin(Plugin):
 
     def PLUGINBEGIN(self, headers, body):
         logging.info("PLUGINBEGIN")
-        logging.debug("headers: %s" % headers)
+        logging.debug("headers: {0!s}".format(headers))
         self.ack()
 
     def PACKAGESETCHANGED(self, headers, body):
         logging.info("PACKAGESETCHANGED")
-        logging.debug("headers: %s" % headers)
+        logging.debug("headers: {0!s}".format(headers))
         print('patchman: sending data')
         servicecmd = '/usr/sbin/patchman-client'
         args = '-n'
@@ -42,7 +42,7 @@ class MyPlugin(Plugin):
 
     def PLUGINEND(self, headers, body):
         logging.info("PLUGINEND")
-        logging.debug("headers: %s" % headers)
+        logging.debug("headers: {0!s}".format(headers))
         self.ack()
 
 plugin = MyPlugin()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:furlongm:patchman?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:furlongm:patchman?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)