### PR TITLE
fixed debian apt-cache ouptut

### DIFF
--- a/client/patchman-client
+++ b/client/patchman-client
@@ -293,7 +293,7 @@ function get_repos {
         fi
         IFS=$OLDIFS read osname shortversion <<<$(echo "${os}" | awk '{print $1,$2}' | cut -d . -f 1,2)
         repo_string="'deb\' \'${osname} ${shortversion} ${host_arch} repo at"
-        repos=`apt-cache policy | grep http: | grep -v Translation | sed -e "s/^ *//g" -e "s/ *$//g" | cut -d " " -f 1,2,3,4`
+        repos=`apt-cache policy | egrep "[0-9]{3} http:" | grep -v Translation | sed -e "s/^ *//g" -e "s/ *$//g" | cut -d " " -f 1,2,3,4`
         dist_repos=`echo "${repos}" | grep -v -e "Packages$"`
         nondist_repos=`echo "${repos}" | grep -e "Packages$"`
         echo "${dist_repos}" | sed -e "s/\([0-9]*\) \(http:.*\) \(.*\/.*\) \(.*\)/${repo_string} \2dists\/\3\/binary-\4' '\1' '\2dists\/\3\/binary-\4'/" >> ${tmpfile_rep}


### PR DESCRIPTION
debian 8 apt-cache policy output is a little bit different. It wrongly parses the output so the patchman process report has problems. So this provides simple fix for it.