### PR TITLE
Add a -P argument, to look for updates when processing pending reports

### DIFF
--- a/sbin/patchman
+++ b/sbin/patchman
@@ -408,11 +408,13 @@ def dns_checks(host=None):
         host.check_rdns()
 
 
-def process_reports(host=None, force=False):
+def process_reports(host=None, force=False, updates=False):
     """ Process all pending reports, specify host to process only a single host
         The --force option forces even processed reports to be reprocessed
         No reports are skipped in case some reports contain repo information
         and others only contain package information.
+        The updates argument is passed to find_updates, to cause the report processing
+        to find all updates for the host.
     """
     reports = []
     if host:
@@ -429,7 +431,7 @@ def process_reports(host=None, force=False):
     info_message.send(sender=None, text=text)
 
     for report in reports:
-        report.process(find_updates=False)
+        report.process(find_updates=updates)
 
 
 def clean_updates():
@@ -505,6 +507,9 @@ def collect_args():
         '-p', '--process-reports', action='store_true',
         help='Process pending Reports')
     parser.add_argument(
+        '-P', '--process-reports-updates', action='store_true',
+        help='Process pending Reports and find updates for hosts with reports')
+    parser.add_argument(
         '-c', '--clean-reports', action='store_true',
         help='Remove all but the last three Reports')
     parser.add_argument(
@@ -554,7 +559,10 @@ def process_args(args):
         clean_reports(args.host)
         showhelp = False
     if args.process_reports:
-        process_reports(args.host, args.force)
+        process_reports(args.host, args.force, False)
+        showhelp = False
+    if args.process_reports_updates:
+        process_reports(args.host, args.force, True)
         showhelp = False
     if args.dbcheck:
         dbcheck()


### PR DESCRIPTION
Patch 2/4:  This calls report.process with an argument of True instead of false when doing a report process.  This allows me to patch a host, send a report to patchman, and then immediately recompute that one host to see if there are missing patches.