### PR TITLE
use full path for patchman-client

### DIFF
--- a/hooks/apt/05patchman
+++ b/hooks/apt/05patchman
@@ -1,1 +1,1 @@
-DPkg::Post-Invoke      { "if [ -x /usr/sbin/patchman-client ]; then echo 'Sending report to patchman server ...'; patchman-client -n ; fi"; };
+DPkg::Post-Invoke      { "if [ -x /usr/sbin/patchman-client ]; then echo 'Sending report to patchman server ...'; /usr/sbin/patchman-client -n ; fi"; };


### PR DESCRIPTION
Some exception happen on "apt-get dist-upgrade" where patchman-client not found because /usr/sbin not in $PATH variable.