### PR TITLE
Fix host updates

### DIFF
--- a/sbin/patchman
+++ b/sbin/patchman
@@ -311,8 +311,7 @@ def host_updates_alt(host=None):
                 phosts.append(fhost)
 
             for phost in phosts:
-                phost.updates.clear()
-                phost.updates = updates
+                phost.updates.set(updates)
                 phost.updated_at = ts
                 phost.save()
                 updated_hosts.append(phost)


### PR DESCRIPTION
Using direct assignment leads to a traceback. Use the .set() call as
suggested by the error message.

Closes: #356
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>