### PR TITLE
ignore epoch for RPM packages

### DIFF
--- a/client/patchman-client
+++ b/client/patchman-client
@@ -176,7 +176,7 @@ get_installed_rpm_packages() {
             echo 'Finding installed rpms...'
         fi
 
-        rpm -qa --queryformat "'%{NAME}' '%{EPOCH}' '%{version}' '%{RELEASE}' '%{ARCH}' 'rpm'\n" 2>/dev/null \
+        rpm -qa --queryformat "'%{NAME}' '%{version}' '%{RELEASE}' '%{ARCH}' 'rpm'\n" 2>/dev/null \
         | sed -e 's/(none)//g' \
         | sed -e 's/\+/%2b/g' >> "${tmpfile_pkg}"
 

--- a/repos/utils.py
+++ b/repos/utils.py
@@ -293,7 +293,6 @@ def extract_yum_packages(data, url):
                               namespaces={'ns': ns})[0].text
             fullversion = elem.xpath('//ns:version',
                                      namespaces={'ns': ns})[0]
-            epoch = fullversion.get('epoch')
             version = fullversion.get('ver')
             release = fullversion.get('rel')
             elem.clear()
@@ -301,10 +300,8 @@ def extract_yum_packages(data, url):
                 del elem.getparent()[0]
 
             if name != '' and version != '' and arch != '':
-                if epoch == '0':
-                    epoch = ''
                 package = PackageString(name=name,
-                                        epoch=epoch,
+                                        epoch='',
                                         version=version,
                                         release=release,
                                         arch=arch,


### PR DESCRIPTION
The packages that are derived from the CEFS errata don't have epoch info, so
they will never match. We can safely remove the epochs as they are rarely
used in RHEL/CentOS. This may cause issues for custom packages though.