### PR TITLE
django3 / 2023 distro support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,43 +5,48 @@ mysql or postgresql instead, see the database configuration section.
 
 
 ## Supported Install Options
-  - [Ubuntu 20.04](#ubuntu-2004-focal)
-  - [Debian 11](#debian-11-bullseye)
-  - [CentOS 8](#centos-8)
+  - [Ubuntu 22.04](#ubuntu-2204-jammy)
+  - [Debian 12](#debian-12-bookworm)
+  - [CentOS 9](#centos-9)
   - [virtualenv + pip](#virtualenv--pip)
   - [Source](#source)
 
 
-### Ubuntu 20.04 (focal)
+### Ubuntu 22.04 (jammy)
 
 ```shell
 curl -sS https://repo.openbytes.ie/openbytes.gpg > /usr/share/keyrings/openbytes.gpg
-echo "deb [signed-by=/usr/share/keyrings/openbytes.gpg] https://repo.openbytes.ie/patchman/ubuntu focal main" > /etc/apt/sources.list.d/patchman.list
+echo "deb [signed-by=/usr/share/keyrings/openbytes.gpg] https://repo.openbytes.ie/patchman/ubuntu jammy main" > /etc/apt/sources.list.d/patchman.list
 apt update
 apt -y install python3-patchman patchman-client
 patchman-manage createsuperuser
 ```
 
-### Debian 11 (bullseye)
+### Debian 12 (bookworm)
 
 ```shell
 curl -sS https://repo.openbytes.ie/openbytes.gpg > /usr/share/keyrings/openbytes.gpg
-echo "deb [signed-by=/usr/share/keyrings/openbytes.gpg] https://repo.openbytes.ie/patchman/debian bullseye main" > /etc/apt/sources.list.d/patchman.list
+echo "deb [signed-by=/usr/share/keyrings/openbytes.gpg] https://repo.openbytes.ie/patchman/debian bookworm main" > /etc/apt/sources.list.d/patchman.list
 apt update
 apt -y install python3-patchman patchman-client
 patchman-manage createsuperuser
 ```
 
-### CentOS 8
+### CentOS 9
+
+This also applies to Rocky/Alma/RHEL
 
 ```shell
+curl -sS https://repo.openbytes.ie/openbytes.gpg > /etc/pki/rpm-gpg/RPM-GPG-KEY-openbytes
 cat <<EOF >> /etc/yum.repos.d/openbytes.repo
 [openbytes]
 name=openbytes
-baseurl=https://repo.openbytes.ie/patchman/el8
+baseurl=https://repo.openbytes.ie/patchman/el9
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-openbytes
 EOF
+update-crypto-policies --set DEFAULT:SHA1
 dnf -y install epel-release
 dnf makecache
 dnf -y install patchman patchman-client
@@ -55,7 +60,7 @@ TBD - not working yet
 
 ```shell
 apt -y install gcc libxml2-dev libxslt1-dev virtualenv python3-dev zlib1g-dev  # (debian/ubuntu)
-dnf -y install gcc libxml2-devel libxslt-devel python3-virtualenv              # (centos/rhel)
+dnf -y install gcc libxml2-devel libxslt-devel python3-virtualenv              # (centos/rocky/alma)
 mkdir /srv/patchman
 cd /srv/patchman
 virtualenv .
@@ -69,7 +74,7 @@ gunicorn patchman.wsgi -b 0.0.0.0:80
 
 ### Source
 
-#### Ubuntu 20.04 (focal)
+#### Ubuntu 22.04 (jammy)
 
 1. Install dependencies
 
@@ -111,7 +116,7 @@ be configured:
 
    * ADMINS - set up an admin email address
    * SECRET_KEY - create a random secret key
-   * STATICFILES_DIRS - should point to /srv/patchman/patchman/static if installing from
+   * STATIC_ROOT - should point to `/srv/patchman/run/static` if installing from
      source
 
 
@@ -211,6 +216,8 @@ ALTER ROLE
 postgres=# ALTER ROLE patchman SET timezone TO 'UTC';
 ALTER ROLE
 postgres=# GRANT ALL PRIVILEGES ON DATABASE patchman to patchman;
+GRANT
+postgres=# GRANT ALL ON SCHEMA public TO patchman;
 GRANT
 ```
 
@@ -314,7 +321,9 @@ apt -y install python3-celery redis python3-redis python-celery-common
 C_FORCE_ROOT=1 celery -b redis://127.0.0.1:6379/0 -A patchman worker -l INFO -E
 ```
 
-#### CentOS / RHEL
+#### CentOS / Rocky / Alma
+
+Currently waiting on https://bugzilla.redhat.com/show_bug.cgi?id=2032543
 
 ```shell
 dnf -y install python3-celery redis python3-redis
@@ -334,8 +343,8 @@ Enable celery by adding `USE_ASYNC_PROCESSING = True` to `/etc/patchman/local_se
 Memcached can optionally be run to reduce the load on the server.
 
 ```shell
-apt -y install memcached python3-memcache   # (debian/ubuntu)
-dnf -y install memcached python3-memcached  # (centos/rhel)
+apt -y install memcached python3-pymemcache  # (debian/ubuntu)
+dnf -y install memcached python3-pymemcache  # (centos/rocky/alma)
 systemctl restart memcached
 ```
 
@@ -344,8 +353,11 @@ and add the following to `/etc/patchman/local_settings.py`
 ```
 CACHES = {
    'default': {
-       'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+       'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
        'LOCATION': '127.0.0.1:11211',
+        'OPTIONS': {
+            'ignore_exc': True,
+        },
    }
 }
 ```

--- a/debian/control
+++ b/debian/control
@@ -3,17 +3,17 @@ Section: python
 Priority: optional
 Maintainer: Marcus Furlong <furlongm@gmail.com>
 Uploaders: Marcus Furlong <furlongm@gmail.com>
-Build-Depends: debhelper (>=12), python3 (>= 3.6), dh-python, dh-exec
-Standards-Version: 4.3.0
+Build-Depends: debhelper (>=13), python3 (>= 3.10), dh-python, dh-exec
+Standards-Version: 4.6.2
 Homepage: https://github.com/furlongm/patchman
 Vcs-Git: git://github.com/furlongm/patchman
 Vcs-Browser: https://github.com/furlongm/patchman
-X-Python3-Version: >= 3.6
+X-Python3-Version: >= 3.10
 
 Package: python3-patchman
 Architecture: all
 Homepage: https://github.com/furlongm/patchman
-Depends: ${misc:Depends}, python3 (>= 3.6), python3-django (>= 2.2),
+Depends: ${misc:Depends}, python3 (>= 3.10), python3-django (>= 3.2),
  python3-django-tagging, python3-django-extensions, python3-django-bootstrap3,
  python3-djangorestframework, python3-django-filters, python3-debian,
  python3-rpm, python3-progressbar, python3-lxml, python3-defusedxml,

--- a/etc/patchman/local_settings.py
+++ b/etc/patchman/local_settings.py
@@ -40,7 +40,10 @@ RUN_GUNICORN = False
 # Enable memcached
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': '127.0.0.1:11211',
+        'OPTIONS': {
+            'ignore_exc': True,
+        },
     }
 }

--- a/patchman/settings.py
+++ b/patchman/settings.py
@@ -61,6 +61,8 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = False
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 DEFAULT_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-Django==2.2.28
+Django==3.2.22
 django-tagging==0.5.0
-django-extensions==3.1.5
-django-bootstrap3==15.0.0
+django-extensions==3.2.1
+django-bootstrap3==23.1
 progressbar==2.5
-python-debian==0.1.43
-lxml==4.7.1
+python-debian==0.1.49
+lxml==4.9.2
 defusedxml==0.7.1
 chardet==4.0.0
 requests==2.27.1
@@ -14,4 +14,4 @@ django-filter==21.1
 humanize==3.13.1
 version-utils==0.3.0
 python-magic==0.4.25
-python-memcached==1.59
+pymemcache==4.0.0

--- a/scripts/rpm-post-install.sh
+++ b/scripts/rpm-post-install.sh
@@ -4,12 +4,13 @@ if [ ! -e /etc/httpd/conf.d/patchman.conf ] ; then
     cp /etc/patchman/apache.conf.example /etc/httpd/conf.d/patchman.conf
 fi
 
-if ! grep /usr/lib/python3.6/site-packages /etc/httpd/conf.d/patchman.conf >/dev/null 2>&1 ; then
-    sed -i -e "s/^\(Define patchman_pythonpath\).*/\1 \/usr\/lib\/python3.6\/site-packages/" \
+if ! grep /usr/lib/python3.9/site-packages /etc/httpd/conf.d/patchman.conf >/dev/null 2>&1 ; then
+    sed -i -e "s/^\(Define patchman_pythonpath\).*/\1 \/usr\/lib\/python3.9\/site-packages/" \
     /etc/httpd/conf.d/patchman.conf
 fi
 
-service httpd reload
+systemctl enable httpd
+systemctl restart httpd
 
 patchman-set-secret-key
 chown apache /etc/patchman/local_settings.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,10 @@ doc_files = README.md AUTHORS COPYING INSTALL.md
 install-script = scripts/rpm-install.sh
 post-install = scripts/rpm-post-install.sh
 requires = /usr/bin/python3
-    python3-django >= 2.2.9
+    python3-django >= 3.2.20
     python3-django-tagging
     python3-django-extensions
-    django-bootstrap3
+    python3-django-bootstrap3
     python3-django-rest-framework
     python3-django-filter
     python3-debian
@@ -19,7 +19,8 @@ requires = /usr/bin/python3
     python3-magic
     python3-humanize
     memcached
-    python3-memcached
+    python3-pyyaml
+    python3-pymemcache
     python3-mod_wsgi
     python3-importlib-metadata
     policycoreutils-python-utils


### PR DESCRIPTION
Outstanding issues:

RHEL-based distros:
~~python-django3 in epel9 - https://bugzilla.redhat.com/show_bug.cgi?id=2033064~~
python-django-filter in epel9 - https://bugzilla.redhat.com/show_bug.cgi?id=2173774
python-django-rest-framework in epel9 - https://bugzilla.redhat.com/show_bug.cgi?id=2174155
~~python3-pymemcache in epel9 - https://bugzilla.redhat.com/show_bug.cgi?id=2133560~~
~~Need to build django-bootstrap3 rpm~~
~~Need to create el9 repo~~

Debian-based distros:
~~Need to build bootstrap3 deb~~
~~Need to create jammy/bookworm repos~~
