### PR TITLE
Speed up debian package list parsing

### DIFF
--- a/client/patchman-client
+++ b/client/patchman-client
@@ -191,23 +191,34 @@ get_installed_deb_packages() {
         if ${verbose} ; then
             echo 'Finding installed debs...'
         fi
-        OLDIFS=${IFS}
-        IFS="
-"
-        dpkg_query_output=$(dpkg-query -W --showformat="\${Status}\|\${Package} \${Version} \${Architecture}\n" \
-                            | egrep '^(install)|(hold) ok installed' \
-                            | sed -e 's/^\(install\|hold\) ok installed|//g')
-        for i in ${dpkg_query_output} ; do
-            IFS=${OLDIFS}
-            read -r name fullversion arch <<<$(echo "${i}" | cut -d " " -f 1,2,3)
-            read -r remaining release <<<$(echo "${fullversion}" | sed -e "s/\(.*\)-\(.*\)/\1 \2/")
-            epoch=$(echo "${remaining}" | cut -d ":" -f 1 -s)
-            version=$(echo "${remaining}" | sed -e "s/.*:\(.*\)/\1/")
-            echo \'${name}\' \'${epoch}\' \'${version}\' \'${release}\' \'${arch}\' \'deb\'>> "${tmpfile_pkg}"
-            if ${debug} ; then
-                echo \'${name}\' \'${epoch}\' \'${version}\' \'${release}\' \'${arch}\' \'deb\'
-            fi
-        done
+        dpkg-query -W --showformat='${Status}|${Package}|${Version}|${Architecture}\n' |
+            awk -f <(cat <<'AWK'
+                /^(install|hold) ok installed\|/ {
+                    split($0, parts, "|");
+                    package = parts[2];
+                    version = parts[3];
+                    architecture = parts[4];
+                    epoch = "";
+                    release = "";
+
+                    if (split(version, epoch_t, ":") > 1) {
+                        epoch = epoch_t[1];
+                        version = substr(version, length(epoch) + 2);
+                    }
+                    n = split(version, version_t, "-");
+                    if (n > 1) {
+                        release = version_t[n]
+                        version = substr(version, 1, length(version) - length(release) - 1);
+                    }
+
+                    print "'" package "'", "'" epoch "'", "'" version "'", "'" release "'", "'" architecture "'", "'deb'"
+                }
+AWK
+            ) >> "${tmpfile_pkg}"
+        if ${debug} ; then
+            echo "'name' 'epoch' 'version' 'release' 'arch' 'type'"
+            cat "${tmpfile_pkg}"
+        fi
     fi
 }
 


### PR DESCRIPTION
Hello,

I investigated as the client was very slow to run (with `-n` option in an `apt` hook) and found that computing package list was taking more than 20 seconds on some machines.

With this change, it takes less than 200 miliseconds, even on a very slow Intel Atom powered server.

A diff on the output on a few machines provided only a IMO-valid difference :
```diff
-'install' '' 'ok' '' 'config-files|linux-image-6.4.0-1-amd64' 'deb'
```
where the package state was:
```ShellSession
$ dpkg-query -W --showformat="\${Status}\|\${Package} \${Version} \${Architecture}\n" linux-image-6.4.0-1-amd64
install ok config-files|linux-image-6.4.0-1-amd64 6.4.4-2 amd64
```
