### PR TITLE
patchman-client - Update yum repo config parsing

### DIFF
--- a/client/patchman-client
+++ b/client/patchman-client
@@ -372,7 +372,7 @@ get_repos() {
         releasever=$(rpm -q --qf "%{version}\n" --whatprovides redhat-release | sort -u)
         let numrepos=$(ls /etc/yum.repos.d/*.repo | wc -l)
         if [ ${numrepos} -gt 0 ] ; then
-            priorities=$(sed -n -e "/^name/h; /priority *=/{ G; s/\n/ /; s/ity *= *\(.*\)/ity=\1/ ; s/\$releasever/${releasever}/ ; s/name=\(.*\)/'\1 ${host_arch}'/ ; p }" /etc/yum.repos.d/*.repo)
+            priorities=$(sed -n -e "/^name/h; /priority *=/{ G; s/\n/ /; s/ity *= *\(.*\)/ity=\1/ ; s/\$releasever/${releasever}/ ; s/name *= *\(.*\)/'\1 ${host_arch}'/ ; p }" /etc/yum.repos.d/*.repo)
         fi
         # replace this with a dedicated awk or simple python script?
         yum_repolist=$(yum repolist enabled --verbose 2>/dev/null | sed -e "s/:\? *([0-9]\+ more)$//g" -e "s/ ([0-9]\+$//g" -e "s/:\? more)$//g" -e "s/'//g" -e "s/%/%%/g")


### PR DESCRIPTION
Supports a [space] around the name key/value

Amazon linux 2 is using both formats which meant the priority wasn't being picked up

`/etc/yum.repos.d/amzn2-extras.repo`
```
...
...
[amzn2extra-epel]
enabled = 1
name = Amazon Extras repo for epel
mirrorlist = $awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/extras/epel/latest/$basearch/mirror.list
gpgcheck = 1
gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2
priority = 10
skip_if_unavailable = 1
report_instanceid = yes
```
and `/etc/yum.repos.d/amzn2-core.repo`
```
[amzn2-core]
name=Amazon Linux 2 core repository
mirrorlist=$awsproto://$amazonlinux.$awsregion.$awsdomain/$releasever/$product/$target/$basearch/mirror.list
priority=10
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2
enabled=1
metadata_expire=300
mirrorlist_expire=300
report_instanceid=yes
...
...
```