### PR TITLE
Remove duplicate results from mirror packages query

### DIFF
--- a/repos/utils.py
+++ b/repos/utils.py
@@ -766,7 +766,7 @@ def find_best_repo(package, hostrepos):
         repo. Returns the best repo.
     """
     best_repo = None
-    package_repos = hostrepos.filter(repo__mirror__packages=package)
+    package_repos = hostrepos.filter(repo__mirror__packages=package).distinct()
 
     if package_repos:
         best_repo = package_repos[0]


### PR DESCRIPTION
I was finding that our patchman update process was getting OOMKilled after we had turned host update processing on (mainly to pickup repo priorities). Over time our epel (`Extra Packages for Enterprise Linux 7 - x86_64 x86_64`) repo has grown to 122 mirrors with the query in `find_best_repo()` returning 12,486,366 results

Using Django's [distinct](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#distinct) has dropped this to a single result