### PR TITLE
Fix post_data curl eval with quotes

### DIFF
--- a/client/patchman-client
+++ b/client/patchman-client
@@ -597,7 +597,7 @@ post_data() {
         echo "${post_command}"
     fi
 
-    result=$(eval ${post_command})
+    result=$(eval "${post_command}")
     retval=${?}
 
     if [ ! ${retval} -eq 0 ] ; then


### PR DESCRIPTION
Without these quotes a "File not found" was given for the curl execution on certain Debian versions. Buster had issues, but Bullseye works fine :shrug:.

The change is also suggested by shellcheck, with the message: 
> SC2086 (info): Double quote to prevent globbing and word splitting.