### PR TITLE
Update signals.py

### DIFF
--- a/patchman/signals.py
+++ b/patchman/signals.py
@@ -17,9 +17,9 @@
 
 from django.dispatch import Signal
 
-progress_info_s = Signal(providing_args=['ptext', 'plength'])
-progress_update_s = Signal(providing_args=['index'])
-info_message = Signal(providing_args=['text'])
-warning_message = Signal(providing_args=['text'])
-error_message = Signal(providing_args=['text'])
-debug_message = Signal(providing_args=['text'])
+progress_info_s = Signal()
+progress_update_s = Signal()
+info_message = Signal()
+warning_message = Signal()
+error_message = Signal()
+debug_message = Signal()


### PR DESCRIPTION
providing_args was deprecated in Django 3.1 and removed in DJango 4.