### PR TITLE
add astra linux version detection

### DIFF
--- a/client/patchman-client
+++ b/client/patchman-client
@@ -348,6 +348,8 @@ get_host_data() {
             os="${NAME}"
         elif [[ "${ID}" =~ "suse" ]] ; then
             os="${PRETTY_NAME}"
+        elif [ "${ID}" == "astra" ] ; then
+            os="${NAME} $(cat /etc/astra_version)"
         else
             os="${NAME} ${VERSION}"
         fi


### PR DESCRIPTION
Hi.
This patch adds astra linux distro version detection.
os-release file in this distro doesn't contain VERSION tag