### PR TITLE
Remove unused dependency 'chardet' from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ django-bootstrap3==23.1
 python-debian==1.0.1
 defusedxml==0.7.1
 PyYAML==6.0.2
-chardet==5.2.0
 requests==2.32.4
 colorama==0.4.6
 djangorestframework==3.15.2


### PR DESCRIPTION
As part of our ongoing research on Python dependency management, we identified a potential improvement in your project’s approach.

Specifically, the dependency `chardet` is listed in `requirements.txt` but doesn’t appear to be used anywhere in the codebase.

Cleaning it up can make your project easier to maintain and a bit safer in the long run.

Hope this is helpful!