### PR TITLE
fix cvss model to match released migration 0010

### DIFF
--- a/security/models.py
+++ b/security/models.py
@@ -84,7 +84,7 @@ class CVSS(models.Model):
     score = models.DecimalField(max_digits=3, decimal_places=1, null=True)
     severity = models.CharField(max_length=128, blank=True, null=True)
     version = models.DecimalField(max_digits=2, decimal_places=1)
-    vector_string = models.CharField(max_length=128, blank=True, null=True)
+    vector_string = models.CharField(max_length=255, blank=True, null=True)
 
     class Meta:
         unique_together = ['score', 'severity', 'version', 'vector_string']


### PR DESCRIPTION
eb09bfe fixed the migrations but missed updating the model definition.
vector_string max_length=128 in the model would reject cvss v4.0 vectors
at the python level and cause makemigrations to generate a backwards
migration. no new migration needed as 0010 already set the db column
to 255.
