### PR TITLE
fix: false kernel update reports when linux-image-generic meta-package is installed

### DIFF
--- a/hosts/models.py
+++ b/hosts/models.py
@@ -576,16 +576,14 @@ class Host(models.Model):
                     break
             if prefix is None or prefix in processed_prefixes:
                 continue
-            processed_prefixes.add(prefix)
 
-            # extract kernel series (e.g. '6.8') to avoid cross-track
-            # comparisons (GA vs HWE); meta-packages like linux-image-generic
-            # yield None, so fall back to the running kernel's series
+            # skip meta-packages (e.g. linux-image-generic) that have no series;
+            # the versioned package (e.g. linux-image-5.15.0-176-generic) will
+            # handle the update check and correctly filter cross-series packages
             installed_series = self.get_deb_kernel_series(pkg_name)
-            if installed_series is None and self.kernel:
-                m = re.match(r'(\d+\.\d+)', self.kernel)
-                if m:
-                    installed_series = m.group(1)
+            if installed_series is None:
+                continue
+            processed_prefixes.add(prefix)
 
             # build endswith filter for flavoured kernels
             name_filter = Q(

--- a/hosts/models.py
+++ b/hosts/models.py
@@ -579,8 +579,13 @@ class Host(models.Model):
             processed_prefixes.add(prefix)
 
             # extract kernel series (e.g. '6.8') to avoid cross-track
-            # comparisons (GA 6.8 vs HWE 6.17 in the same repo)
+            # comparisons (GA vs HWE); meta-packages like linux-image-generic
+            # yield None, so fall back to the running kernel's series
             installed_series = self.get_deb_kernel_series(pkg_name)
+            if installed_series is None and self.kernel:
+                m = re.match(r'(\d+\.\d+)', self.kernel)
+                if m:
+                    installed_series = m.group(1)
 
             # build endswith filter for flavoured kernels
             name_filter = Q(


### PR DESCRIPTION
## Problem

Hosts running Ubuntu 22.04 with `linux-image-generic` (the GA meta-package) installed were incorrectly reported by patchman as having an available kernel update to the HWE series (e.g. `linux-image-6.8.0-106-generic`) even though `apt upgrade` would never offer it.

### Root cause

`find_deb_kernel_updates` extracts the kernel series (e.g. `5.15`) from each installed kernel package name to avoid cross-track comparisons (GA vs HWE). For meta-packages like `linux-image-generic`, `get_deb_kernel_series()` returns `None` because the name contains no version number. The series guard was `if installed_series is not None`, so meta-packages bypassed it entirely.

Additionally, `processed_prefixes` marks the `linux-image-` prefix as consumed by the meta-package, preventing the versioned package (`linux-image-5.15.0-176-generic`) from being processed later with the correct `5.15` series. The net result: the highest `linux-image-*-generic` in the repo regardless of kernel series was reported as an update.

## Fix

When `get_deb_kernel_series()` returns `None` for a meta-package, fall back to parsing the series from `self.kernel` (the running kernel string). This ensures the series guard always runs, correctly excluding packages from a different kernel track.
