### PR TITLE
Fix setuptools warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bdist_rpm]
 doc_files = README.md AUTHORS COPYING INSTALL.md
-install-script = scripts/rpm-install.sh
-post-install = scripts/rpm-post-install.sh
+install_script = scripts/rpm-install.sh
+post_install = scripts/rpm-post-install.sh
 requires = /usr/bin/python3
     python3-django >= 4.2.20
     python3-django-taggit

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     author='Marcus Furlong',
     author_email='furlongm@gmail.com',
     description='Django based patch status monitoring tool for linux systems',
-    license='GPLv3',
+    license='GPL-3.0-only',
     keywords='django patch status monitoring linux spacewalk patchman',
     packages=find_packages(),
     install_requires=install_requires,
@@ -84,6 +84,5 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     ],
 )


### PR DESCRIPTION
This fixes a number of obnoxious setuptools warnings that I see scrolling by when I build with `python -m build`:

```
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools >= 40.8.0
* Getting build dependencies for sdist...
/tmp/build-env-7f8vloah/lib/python3.12/site-packages/setuptools/dist.py:599: SetuptoolsDeprecationWarning: Invalid dash-separated key 'install-script' in 'bdist_rpm' (setup.cfg), please use the underscore name 'install_script' instead.
!!

        ********************************************************************************
        Usage of dash-separated 'install-script' will not be supported in future
        versions. Please use the underscore name 'install_script' instead.


        Available configuration options are listed in:
        https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://github.com/pypa/setuptools/discussions/5011 for details.
        ********************************************************************************

!!
  opt = self._enforce_underscore(opt, section)
/tmp/build-env-7f8vloah/lib/python3.12/site-packages/setuptools/dist.py:599: SetuptoolsDeprecationWarning: Invalid dash-separated key 'post-install' in 'bdist_rpm' (setup.cfg), please use the underscore name 'post_install' instead.
!!

        ********************************************************************************
        Usage of dash-separated 'post-install' will not be supported in future
        versions. Please use the underscore name 'post_install' instead.


        Available configuration options are listed in:
        https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://github.com/pypa/setuptools/discussions/5011 for details.
        ********************************************************************************

!!
  opt = self._enforce_underscore(opt, section)
/tmp/build-env-7f8vloah/lib/python3.12/site-packages/setuptools/dist.py:599: SetuptoolsDeprecationWarning: Invalid dash-separated key 'install-script' in 'bdist_rpm' (setup.cfg), please use the underscore name 'install_script' instead.
!!

        ********************************************************************************
        Usage of dash-separated 'install-script' will not be supported in future
        versions. Please use the underscore name 'install_script' instead.
        (Affected: patchman).

        Available configuration options are listed in:
        https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://github.com/pypa/setuptools/discussions/5011 for details.
        ********************************************************************************

!!
  opt = self._enforce_underscore(opt, section)
/tmp/build-env-7f8vloah/lib/python3.12/site-packages/setuptools/dist.py:599: SetuptoolsDeprecationWarning: Invalid dash-separated key 'post-install' in 'bdist_rpm' (setup.cfg), please use the underscore name 'post_install' instead.
!!

        ********************************************************************************
        Usage of dash-separated 'post-install' will not be supported in future
        versions. Please use the underscore name 'post_install' instead.
        (Affected: patchman).

        Available configuration options are listed in:
        https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://github.com/pypa/setuptools/discussions/5011 for details.
        ********************************************************************************

!!
  opt = self._enforce_underscore(opt, section)
/tmp/build-env-7f8vloah/lib/python3.12/site-packages/setuptools/dist.py:765: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 (GPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running egg_info
writing patchman.egg-info/PKG-INFO
writing dependency_links to patchman.egg-info/dependency_links.txt
writing requirements to patchman.egg-info/requires.txt
writing top-level names to patchman.egg-info/top_level.txt
reading manifest file 'patchman.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'COPYING'
adding license file 'AUTHORS'
writing manifest file 'patchman.egg-info/SOURCES.txt'
* Building sdist...
/tmp/build-env-7f8vloah/lib/python3.12/site-packages/setuptools/dist.py:599: SetuptoolsDeprecationWarning: Invalid dash-separated key 'install-script' in 'bdist_rpm' (setup.cfg), please use the underscore name 'install_script' instead.
!!

        ********************************************************************************
        Usage of dash-separated 'install-script' will not be supported in future
        versions. Please use the underscore name 'install_script' instead.
        (Affected: patchman).

        Available configuration options are listed in:
        https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://github.com/pypa/setuptools/discussions/5011 for details.
        ********************************************************************************

!!
  opt = self._enforce_underscore(opt, section)
/tmp/build-env-7f8vloah/lib/python3.12/site-packages/setuptools/dist.py:599: SetuptoolsDeprecationWarning: Invalid dash-separated key 'post-install' in 'bdist_rpm' (setup.cfg), please use the underscore name 'post_install' instead.
!!

        ********************************************************************************
        Usage of dash-separated 'post-install' will not be supported in future
        versions. Please use the underscore name 'post_install' instead.
        (Affected: patchman).

        Available configuration options are listed in:
        https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://github.com/pypa/setuptools/discussions/5011 for details.
        ********************************************************************************

!!
  opt = self._enforce_underscore(opt, section)
/tmp/build-env-7f8vloah/lib/python3.12/site-packages/setuptools/dist.py:765: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 (GPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running sdist
running egg_info
writing patchman.egg-info/PKG-INFO
...
```

There are also a number of "Package would be ignored" warnings for directories containing templates (such as errata.templates.errata), but I'm unsure what to do about those.