### PR TITLE
Fix UnboundLocalError while recovering from an error

### DIFF
--- a/hosts/utils.py
+++ b/hosts/utils.py
@@ -46,6 +46,7 @@ def get_or_create_host(report, arch, osvariant, domain):
         except herror:
             report.host = report.report_ip
         report.save()
+    host = None
     try:
         with transaction.atomic():
             host, created = Host.objects.get_or_create(


### PR DESCRIPTION
See https://github.com/furlongm/patchman/issues/690#issuecomment-4574985291: if you upgrade a Patchman 3 setup to Patchman 4, the migrations don't correctly alter the hosts_host table and leave the tags column as NOT NULL, which then causes issues processing reports for previously unseen hosts.  Host.objects.get_or_create() raises, the exception is caught and logged, and then subsequent `if host:` check fails with an

    UnboundLocalError: cannot access local variable 'host' where it is not associated with a value

(This commit doesn't actually fix the processing error itself, you need a database schema fix for that -- drop the no-longer-used `tags` column from the `hosts_host` table.)